### PR TITLE
v1.4.9 peerStatus fix

### DIFF
--- a/avax-app.js
+++ b/avax-app.js
@@ -83,7 +83,7 @@ const update = async () => {
                     peerStatus.labels(node.version, 'down').set(0);
                     nodeVersions.push(node.version);
                 }
-                peerStatus.labels(node.version, node.up ? 'up' : 'down').inc();
+                peerStatus.labels(node.version, 'up').inc();
             }
         } catch (err) {
             console.log(err);


### PR DESCRIPTION
v1.4.9 breaks peerStatus up/down labels, so this is the fix